### PR TITLE
Compatibility 

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -45,8 +45,6 @@ jobs:
       run: |
         python3 setup.py develop
         pytest
-      env:
-        CYTHONIZE: 1
         
     - name: Build sdist
       working-directory: ./python

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=55.0", "Cython>=3", "pyarrow==10"]
+requires = ["setuptools>=55.0", "Cython>=3", "pyarrow>=10"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -17,7 +17,7 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
-  "pyarrow>=6"
+  "pyarrow>=10"
 ]
 
 [tool.setuptools.packages.find]

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=55.0", "Cython>=3", "pyarrow>=12"]
+requires = ["setuptools>=55.0", "Cython>=3", "pyarrow>=10"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -17,7 +17,7 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
-  "pyarrow>=6"
+  "pyarrow>=10"
 ]
 
 [tool.setuptools.packages.find]

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=55.0", "Cython>=3", "pyarrow>=10"]
+requires = ["setuptools>=55.0", "Cython>=3", "pyarrow==10"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -17,7 +17,7 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
-  "pyarrow>=10"
+  "pyarrow>=6"
 ]
 
 [tool.setuptools.packages.find]

--- a/python/setup.py
+++ b/python/setup.py
@@ -56,7 +56,7 @@ extensions = [
         library_dirs = pyarrow.get_library_dirs(),
         libraries=["arrow", "parquet"], 
         language = "c++",
-        extra_compile_args = ['/std:c++20'] if sys.platform.startswith('win') else ['-std=c++20']
+        extra_compile_args = ['/std:c++20'] if sys.platform.startswith('win') else ['-std=c++14']
     )
 ]
 

--- a/python/setup.py
+++ b/python/setup.py
@@ -56,7 +56,7 @@ extensions = [
         library_dirs = pyarrow.get_library_dirs(),
         libraries=["arrow", "parquet"], 
         language = "c++",
-        extra_compile_args = ['/std:c++20'] if sys.platform.startswith('win') else ['-std=c++14']
+        extra_compile_args = ['/std:c++17'] if sys.platform.startswith('win') else ['-std=c++17']
     )
 ]
 


### PR DESCRIPTION
- Use C++17 instead of C++20
- Avoid Cythonizing in the CI (so we check if the checked-in code is compilable and functional)
- Use older Pyarrow