### PR TITLE
CXX11_ABI compatibility with pyarrow

### DIFF
--- a/.github/workflows/python-cd.yml
+++ b/.github/workflows/python-cd.yml
@@ -52,7 +52,7 @@ jobs:
       env:
         CIBW_REPAIR_WHEEL_COMMAND_LINUX: auditwheel repair --exclude libarrow.so.1400 --exclude libparquet.so.1400 -w {dest_dir} {wheel}
         CIBW_ENVIRONMENT: CYTHONIZE=1
-        CIBW_BUILD_VERBOSITY: 3
+        CIBW_BUILD_VERBOSITY: 1
         # We use manylinux_2_28 for ABI compatibility with pyarrow
         # With the default image we were getting "undefined symbol: _ZNK5arrow6Status8ToStringEv" error (e.g https://github.com/ray-project/ray/issues/24566) 
         CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_28 

--- a/.github/workflows/python-cd.yml
+++ b/.github/workflows/python-cd.yml
@@ -51,8 +51,10 @@ jobs:
       # to supply options, put them in 'env', like:
       env:
         CIBW_REPAIR_WHEEL_COMMAND_LINUX: auditwheel repair --exclude libarrow.so.1400 --exclude libparquet.so.1400 -w {dest_dir} {wheel}
-        CIBW_ENVIRONMENT: CYTHONIZE=1
+        CIBW_ENVIRONMENT: CYTHONIZE=0
         CIBW_BUILD_VERBOSITY: 3
+        # We use manylinux_2_28 for ABI compatibility with pyarrow
+        # With the default image we were getting "undefined symbol: _ZNK5arrow6Status8ToStringEv" error (e.g https://github.com/ray-project/ray/issues/24566) 
         CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_28 
         # Disable unsupported builds
         CIBW_SKIP: "pp* *_i686 *-musllinux_* *win32" 

--- a/.github/workflows/python-cd.yml
+++ b/.github/workflows/python-cd.yml
@@ -51,7 +51,7 @@ jobs:
       # to supply options, put them in 'env', like:
       env:
         CIBW_REPAIR_WHEEL_COMMAND_LINUX: auditwheel repair --exclude libarrow.so.1400 --exclude libparquet.so.1400 -w {dest_dir} {wheel}
-        CIBW_ENVIRONMENT: CYTHONIZE=0
+        CIBW_ENVIRONMENT: CYTHONIZE=1
         CIBW_BUILD_VERBOSITY: 3
         # We use manylinux_2_28 for ABI compatibility with pyarrow
         # With the default image we were getting "undefined symbol: _ZNK5arrow6Status8ToStringEv" error (e.g https://github.com/ray-project/ray/issues/24566) 

--- a/.github/workflows/python-cd.yml
+++ b/.github/workflows/python-cd.yml
@@ -53,6 +53,7 @@ jobs:
         CIBW_REPAIR_WHEEL_COMMAND_LINUX: auditwheel repair --exclude libarrow.so.1400 --exclude libparquet.so.1400 -w {dest_dir} {wheel}
         CIBW_ENVIRONMENT: CYTHONIZE=1
         CIBW_BUILD_VERBOSITY: 3
+        CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_28 
         # Disable unsupported builds
         CIBW_SKIP: "pp* *_i686 *-musllinux_* *win32" 
 

--- a/.github/workflows/python-cd.yml
+++ b/.github/workflows/python-cd.yml
@@ -52,7 +52,7 @@ jobs:
       env:
         CIBW_REPAIR_WHEEL_COMMAND_LINUX: auditwheel repair --exclude libarrow.so.1400 --exclude libparquet.so.1400 -w {dest_dir} {wheel}
         CIBW_ENVIRONMENT: CYTHONIZE=1
-        CIBW_BUILD_VERBOSITY: 1
+        CIBW_BUILD_VERBOSITY: 3
         # Disable unsupported builds
         CIBW_SKIP: "pp* *_i686 *-musllinux_* *win32" 
 

--- a/python/setup.py
+++ b/python/setup.py
@@ -65,8 +65,11 @@ def is_cxx11_abi():
 
 def get_extension_modules():
     extra_compile_args = ['/std:c++17'] if sys.platform.startswith('win') else ['-std=c++17']
-    if not sys.platform.startswith('win') and not is_cxx11_abi():
-        extra_compile_args.append("-D_GLIBCXX_USE_CXX11_ABI=0")
+    if not sys.platform.startswith('win'):
+        if is_cxx11_abi():
+            extra_compile_args.append("-D_GLIBCXX_USE_CXX11_ABI=1")
+        else 
+            extra_compile_args.append("-D_GLIBCXX_USE_CXX11_ABI=0")
 
     # Define your extension
     extensions = [

--- a/python/setup.py
+++ b/python/setup.py
@@ -69,7 +69,7 @@ def get_extension_modules():
         if is_cxx11_abi():
             extra_compile_args.append("-D_GLIBCXX_USE_CXX11_ABI=1")
         else:
-            extra_compile_args.append("-D_GLIBCXX_USE_CXX11_ABI=1")
+            extra_compile_args.append("-D_GLIBCXX_USE_CXX11_ABI=0")
 
     # Define your extension
     extensions = [

--- a/python/setup.py
+++ b/python/setup.py
@@ -69,7 +69,7 @@ def get_extension_modules():
         if is_cxx11_abi():
             extra_compile_args.append("-D_GLIBCXX_USE_CXX11_ABI=1")
         else:
-            extra_compile_args.append("-D_GLIBCXX_USE_CXX11_ABI=0")
+            extra_compile_args.append("-D_GLIBCXX_USE_CXX11_ABI=1")
 
     # Define your extension
     extensions = [

--- a/python/setup.py
+++ b/python/setup.py
@@ -49,18 +49,40 @@ class PyTest(TestCommand):
         errno = pytest.main(self.pytest_args)
         sys.exit(errno)
 
-# Define your extension
-extensions = [
-    Extension( "palletjack.palletjack_cython", ["palletjack/palletjack_cython.pyx", "palletjack/palletjack.cc"],
-        include_dirs = [pyarrow.get_include(), numpy.get_include()],  
-        library_dirs = pyarrow.get_library_dirs(),
-        libraries=["arrow", "parquet"], 
-        language = "c++",
-        extra_compile_args = ['/std:c++17'] if sys.platform.startswith('win') else ['-std=c++17'],
-    )
-]
+def is_cxx11_abi():
+    import pathlib
+
+    import pyarrow.lib
+
+    binary_so = pathlib.Path(pyarrow.lib.__file__).read_bytes()
+
+    # Check for an old CXXABI symbol in the main library. This one is quite stable across all Arrow releases.
+    # arrow::Status::ToString() -> std::string
+    if b"_ZNK5arrow6Status8ToStringEv" in binary_so:
+        return False
+    # Here we can add other symbols to check for if future releases would come with a different API.
+    return True
+
+def get_extension_modules():
+     extra_compile_args = ['/std:c++17'] if sys.platform.startswith('win') else ['-std=c++17']
+    if not sys.platform.startswith('win') and not is_cxx11_abi(): extra_compile_args.append("-D_GLIBCXX_USE_CXX11_ABI=0")
+
+    # Define your extension
+    extensions = [
+        Extension( "palletjack.palletjack_cython", ["palletjack/palletjack_cython.pyx", "palletjack/palletjack.cc"],
+            include_dirs = [pyarrow.get_include(), numpy.get_include()],  
+            library_dirs = pyarrow.get_library_dirs(),
+            libraries=["arrow", "parquet"], 
+            language = "c++",
+            extra_compile_args = ['/std:c++17'] if sys.platform.startswith('win') else ['-std=c++17'],
+        )
+    ]
+
+    return extensions
 
 CYTHONIZE = bool(int(os.getenv("CYTHONIZE", 0))) and cythonize is not None
+
+extensions = get_extension_modules()
 
 if CYTHONIZE:
     compiler_directives = {"language_level": 3, "embedsignature": True}

--- a/python/setup.py
+++ b/python/setup.py
@@ -77,7 +77,7 @@ def get_extension_modules():
             include_dirs = [pyarrow.get_include(), numpy.get_include()],  
             library_dirs = pyarrow.get_library_dirs(),
             libraries=["arrow", "parquet"], 
-            language = "c",
+            language = "c++",
             extra_compile_args = extra_compile_args,
         )
     ]

--- a/python/setup.py
+++ b/python/setup.py
@@ -68,7 +68,7 @@ def get_extension_modules():
     if not sys.platform.startswith('win'):
         if is_cxx11_abi():
             extra_compile_args.append("-D_GLIBCXX_USE_CXX11_ABI=1")
-        else 
+        else:
             extra_compile_args.append("-D_GLIBCXX_USE_CXX11_ABI=0")
 
     # Define your extension

--- a/python/setup.py
+++ b/python/setup.py
@@ -77,7 +77,7 @@ def get_extension_modules():
             include_dirs = [pyarrow.get_include(), numpy.get_include()],  
             library_dirs = pyarrow.get_library_dirs(),
             libraries=["arrow", "parquet"], 
-            language = "c++",
+            language = "c",
             extra_compile_args = extra_compile_args,
         )
     ]

--- a/python/setup.py
+++ b/python/setup.py
@@ -75,7 +75,7 @@ def get_extension_modules():
             library_dirs = pyarrow.get_library_dirs(),
             libraries=["arrow", "parquet"], 
             language = "c++",
-            extra_compile_args = ['/std:c++17'] if sys.platform.startswith('win') else ['-std=c++17'],
+            extra_compile_args = extra_compile_args,
         )
     ]
 

--- a/python/setup.py
+++ b/python/setup.py
@@ -65,7 +65,8 @@ def is_cxx11_abi():
 
 def get_extension_modules():
      extra_compile_args = ['/std:c++17'] if sys.platform.startswith('win') else ['-std=c++17']
-    if not sys.platform.startswith('win') and not is_cxx11_abi(): extra_compile_args.append("-D_GLIBCXX_USE_CXX11_ABI=0")
+    if not sys.platform.startswith('win') and not is_cxx11_abi():
+        extra_compile_args.append("-D_GLIBCXX_USE_CXX11_ABI=0")
 
     # Define your extension
     extensions = [

--- a/python/setup.py
+++ b/python/setup.py
@@ -64,7 +64,7 @@ def is_cxx11_abi():
     return True
 
 def get_extension_modules():
-     extra_compile_args = ['/std:c++17'] if sys.platform.startswith('win') else ['-std=c++17']
+    extra_compile_args = ['/std:c++17'] if sys.platform.startswith('win') else ['-std=c++17']
     if not sys.platform.startswith('win') and not is_cxx11_abi():
         extra_compile_args.append("-D_GLIBCXX_USE_CXX11_ABI=0")
 


### PR DESCRIPTION
Pyarrow is built with 'manylinux_2_28' image so we need to use it as well.