### PR TITLE
In-memory index data

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -173,7 +173,7 @@ jobs:
     - name: Test with pytest
       run: |
         pip install PalletJack --pre --find-links ./dist --break-system-packages --only-binary=:all:
-        pip install PalletJack --pre --find-links ./dist --break-system-packages --only-binary=:all: --force-reinstall --no-index
+        pip install PalletJack --pre --find-links ./dist --break-system-packages --only-binary=:all: --force-reinstall --no-index --no-deps
         python3 python/test/test_palletjack.py
 
   benchmarks:
@@ -201,7 +201,7 @@ jobs:
     - name: Run benchmarks
       run: |
         pip install PalletJack --pre --find-links ./dist --break-system-packages --force-reinstall 
-        pip install PalletJack --pre --find-links ./dist --break-system-packages --force-reinstall --no-index
+        pip install PalletJack --pre --find-links ./dist --break-system-packages --force-reinstall --no-index --no-deps
         python3 ./benchmarks/benchmark_palletjack_metadata.py
 
   publish:

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -174,7 +174,7 @@ jobs:
       run: |
         # Keep in mind that if the local and remote versions are the same, the remote version will be installed
         pip install PalletJack --pre --find-links ./dist --break-system-packages --only-binary=:all:
-        # So now make sure that local version is being installed 
+        # So now ensure that the local version is installed 
         pip install PalletJack --pre --find-links ./dist --break-system-packages --only-binary=:all: --force-reinstall --no-index --no-deps
         python3 python/test/test_palletjack.py
 
@@ -204,7 +204,7 @@ jobs:
       run: |
         # Keep in mind that if the local and remote versions are the same, the remote version will be installed
         pip install PalletJack --pre --find-links ./dist --break-system-packages --only-binary=:all:
-        # So now make sure that local version is being installed 
+        # So now ensure that the local version is installed 
         pip install PalletJack --pre --find-links ./dist --break-system-packages --only-binary=:all: --force-reinstall --no-index --no-deps
         python3 ./benchmarks/benchmark_palletjack_metadata.py
 

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -173,6 +173,7 @@ jobs:
     - name: Test with pytest
       run: |
         pip install PalletJack --pre --find-links ./dist --break-system-packages --only-binary=:all:
+        pip install PalletJack --pre --find-links ./dist --break-system-packages --only-binary=:all: --force-reinstall --no-index
         python3 python/test/test_palletjack.py
 
   benchmarks:
@@ -198,8 +199,9 @@ jobs:
         merge-multiple: true
 
     - name: Run benchmarks
-      run: |      
-        pip install PalletJack --pre --find-links ./dist --break-system-packages
+      run: |
+        pip install PalletJack --pre --find-links ./dist --break-system-packages --force-reinstall 
+        pip install PalletJack --pre --find-links ./dist --break-system-packages --force-reinstall --no-index
         python3 ./benchmarks/benchmark_palletjack_metadata.py
 
   publish:

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -172,7 +172,9 @@ jobs:
           
     - name: Test with pytest
       run: |
+        # Mind that if local and remote versions are the same, remote version will be installed
         pip install PalletJack --pre --find-links ./dist --break-system-packages --only-binary=:all:
+        # So now make sure that local version is being installed 
         pip install PalletJack --pre --find-links ./dist --break-system-packages --only-binary=:all: --force-reinstall --no-index --no-deps
         python3 python/test/test_palletjack.py
 
@@ -200,8 +202,10 @@ jobs:
 
     - name: Run benchmarks
       run: |
-        pip install PalletJack --pre --find-links ./dist --break-system-packages --force-reinstall 
-        pip install PalletJack --pre --find-links ./dist --break-system-packages --force-reinstall --no-index --no-deps
+        # Mind that if local and remote versions are the same, remote version will be installed
+        pip install PalletJack --pre --find-links ./dist --break-system-packages --only-binary=:all:
+        # So now make sure that local version is being installed 
+        pip install PalletJack --pre --find-links ./dist --break-system-packages --only-binary=:all: --force-reinstall --no-index --no-deps
         python3 ./benchmarks/benchmark_palletjack_metadata.py
 
   publish:

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -172,7 +172,7 @@ jobs:
           
     - name: Test with pytest
       run: |
-        # Mind that if local and remote versions are the same, remote version will be installed
+        # Keep in mind that if the local and remote versions are the same, the remote version will be installed
         pip install PalletJack --pre --find-links ./dist --break-system-packages --only-binary=:all:
         # So now make sure that local version is being installed 
         pip install PalletJack --pre --find-links ./dist --break-system-packages --only-binary=:all: --force-reinstall --no-index --no-deps
@@ -202,7 +202,7 @@ jobs:
 
     - name: Run benchmarks
       run: |
-        # Mind that if local and remote versions are the same, remote version will be installed
+        # Keep in mind that if the local and remote versions are the same, the remote version will be installed
         pip install PalletJack --pre --find-links ./dist --break-system-packages --only-binary=:all:
         # So now make sure that local version is being installed 
         pip install PalletJack --pre --find-links ./dist --break-system-packages --only-binary=:all: --force-reinstall --no-index --no-deps

--- a/benchmarks/benchmark_palletjack_metadata.py
+++ b/benchmarks/benchmark_palletjack_metadata.py
@@ -1,7 +1,6 @@
 import palletjack as pj
 import pyarrow.parquet as pq
 import pyarrow as pa
-import numpy as np
 import pyarrow.fs as fs
 import concurrent.futures
 import time

--- a/benchmarks/benchmark_palletjack_metadata.py
+++ b/benchmarks/benchmark_palletjack_metadata.py
@@ -7,7 +7,6 @@ import concurrent.futures
 import time
 import os
 
-
 row_groups = 200
 columns = 200
 chunk_size = 1000

--- a/benchmarks/benchmark_palletjack_metadata.py
+++ b/benchmarks/benchmark_palletjack_metadata.py
@@ -1,6 +1,7 @@
 import palletjack as pj
 import pyarrow.parquet as pq
 import pyarrow as pa
+import numpy as np
 import pyarrow.fs as fs
 import concurrent.futures
 import time

--- a/benchmarks/benchmark_palletjack_metadata.py
+++ b/benchmarks/benchmark_palletjack_metadata.py
@@ -213,6 +213,7 @@ print(f"Reading multiple columns using arrow (multi-threaded) {measure_reading(8
 print(f"Reading multiple columns using palletjack (multi-threaded) {measure_reading(8, worker_palletjack_columns):.3f} seconds")
 print(".")
 
+print(f"Reading a single row group and column metadata using in-memory palletjack (single-threaded) {measure_reading(1, worker_inmemory_palletjack_row_group_column_metadata):.3f} seconds")
 print(f"Reading a single row group and column metadata using palletjack (single-threaded) {measure_reading(1, worker_palletjack_row_group_column_metadata):.3f} seconds")
 print(f"Reading a single row group metadata using palletjack (single-threaded) {measure_reading(1, worker_palletjack_row_group_metadata):.3f} seconds")
 print(f"Reading a single column metadata using palletjack (single-threaded) {measure_reading(1, worker_palletjack_column_metadata):.3f} seconds")

--- a/benchmarks/benchmark_palletjack_metadata.py
+++ b/benchmarks/benchmark_palletjack_metadata.py
@@ -112,9 +112,8 @@ def worker_palletjack_column_name_metadata():
     for i in range(0, int(n_reads / work_items)):
         pj.read_metadata(index_path, column_names = [f'column_{i % columns}'])
 
-def worker_inmemory_palletjack_row_group_column_metadata():
+def worker_inmemory_palletjack_row_group_column_metadata(index_data):
 
-    index_data = fs.LocalFileSystem().open_input_stream(index_path).readall()
     for i in range(0, int(n_reads / work_items)):
         pj.read_metadata(index_data = index_data, row_groups = [i % row_groups], column_indices = [i % columns])
 
@@ -179,6 +178,7 @@ def measure_reading(max_workers, worker):
 
 table = get_table()
 genrate_data(table)
+index_data = fs.LocalFileSystem().open_input_stream(index_path).readall()
 
 print(f"Reading a single row group using arrow (single-threaded) {measure_reading(1, worker_arrow_row_group):.2f} seconds")
 print(f"Reading a single row group using palletjack (single-threaded) {measure_reading(1, worker_palletjack_row_group):.2f} seconds")
@@ -212,7 +212,7 @@ print(f"Reading multiple columns using arrow (multi-threaded) {measure_reading(8
 print(f"Reading multiple columns using palletjack (multi-threaded) {measure_reading(8, worker_palletjack_columns):.3f} seconds")
 print(".")
 
-print(f"Reading a single row group and column metadata using in-memory palletjack (single-threaded) {measure_reading(1, worker_inmemory_palletjack_row_group_column_metadata):.3f} seconds")
+print(f"Reading a single row group and column metadata using in-memory palletjack (single-threaded) {measure_reading(1, lambda:worker_inmemory_palletjack_row_group_column_metadata(index_data)):.3f} seconds")
 print(f"Reading a single row group and column metadata using palletjack (single-threaded) {measure_reading(1, worker_palletjack_row_group_column_metadata):.3f} seconds")
 print(f"Reading a single row group metadata using palletjack (single-threaded) {measure_reading(1, worker_palletjack_row_group_metadata):.3f} seconds")
 print(f"Reading a single column metadata using palletjack (single-threaded) {measure_reading(1, worker_palletjack_column_metadata):.3f} seconds")
@@ -220,7 +220,7 @@ print(f"Reading a single column(name) metadata using palletjack (single-threaded
 print(f"Reading a metadata using arrow (single-threaded) {measure_reading(1, worker_arrow_metadata):.3f} seconds")
 print(".")
 
-print(f"Reading a single row group and column metadata using in-memory palletjack (multi-threaded) {measure_reading(8, worker_inmemory_palletjack_row_group_column_metadata):.3f} seconds")
+print(f"Reading a single row group and column metadata using in-memory palletjack (multi-threaded) {measure_reading(8, lambda:worker_inmemory_palletjack_row_group_column_metadata(index_data)):.3f} seconds")
 print(f"Reading a single row group and column metadata using palletjack (multi-threaded) {measure_reading(8, worker_palletjack_row_group_column_metadata):.3f} seconds")
 print(f"Reading a single row group metadata using palletjack (multi-threaded) {measure_reading(8, worker_palletjack_row_group_metadata):.3f} seconds")
 print(f"Reading a single column metadata using palletjack (multi-threaded) {measure_reading(8, worker_palletjack_column_metadata):.3f} seconds")

--- a/python/palletjack/cpalletjack.pxd
+++ b/python/palletjack/cpalletjack.pxd
@@ -7,3 +7,4 @@ from pyarrow._parquet cimport *
 cdef extern from "palletjack.h":
     cdef void GenerateMetadataIndex(const char *parquet_path, const char *index_file_path) nogil except +
     cdef shared_ptr[CFileMetaData] ReadMetadata(const char *index_file_path, const vector[uint32_t] row_groups, const vector[uint32_t] column_indices, const vector[string] column_names) nogil except +
+    cdef shared_ptr[CFileMetaData] ReadMetadata(const unsigned char *index_data, size_t index_data_length, const vector[uint32_t] row_groups, const vector[uint32_t] column_indices, const vector[string] column_names) nogil except +

--- a/python/palletjack/cpalletjack.pxd
+++ b/python/palletjack/cpalletjack.pxd
@@ -5,6 +5,7 @@ from libc.stdint cimport uint32_t
 from pyarrow._parquet cimport *
 
 cdef extern from "palletjack.h":
+    cdef vector[char] GenerateMetadataIndex(const char *parquet_path) nogil except +
     cdef void GenerateMetadataIndex(const char *parquet_path, const char *index_file_path) nogil except +
     cdef shared_ptr[CFileMetaData] ReadMetadata(const char *index_file_path, const vector[uint32_t] row_groups, const vector[uint32_t] column_indices, const vector[string] column_names) nogil except +
     cdef shared_ptr[CFileMetaData] ReadMetadata(const unsigned char *index_data, size_t index_data_length, const vector[uint32_t] row_groups, const vector[uint32_t] column_indices, const vector[string] column_names) nogil except +

--- a/python/palletjack/palletjack.cc
+++ b/python/palletjack/palletjack.cc
@@ -39,14 +39,14 @@ struct DataHeader
     uint32_t column_names_length = 0;
     uint32_t metadata_length = 0;
 
-    uint32_t get_num_rows_offsets_size() { return 2; }                                   // 2
-    uint32_t get_row_numbers_size() { return row_groups; }                               // rg
-    uint32_t get_schema_offsets_size() { return 1 + 1 + columns + 1; }                   // 1 + 1 + c + 1
-    uint32_t get_schema_num_children_offsets_size() { return (columns + 1) * (1 + 1); }  // (c + 1) * (1 + 1)
-    uint32_t get_row_groups_offsets_size() { return 1 + row_groups + 1; }                // 1 + rg + 1
-    uint32_t get_column_orders_offsets_size() { return 1 + columns + 1; }                // 1 + c + 1
-    uint32_t get_column_chunks_offsets_size() { return row_groups * (1 + columns + 1); } // rg * (1 + c + 1)
-    uint32_t get_body_size()
+    uint32_t get_num_rows_offsets_size() const { return 2; }                                   // 2
+    uint32_t get_row_numbers_size() const { return row_groups; }                               // rg
+    uint32_t get_schema_offsets_size() const { return 1 + 1 + columns + 1; }                   // 1 + 1 + c + 1
+    uint32_t get_schema_num_children_offsets_size() const { return (columns + 1) * (1 + 1); }  // (c + 1) * (1 + 1)
+    uint32_t get_row_groups_offsets_size() const { return 1 + row_groups + 1; }                // 1 + rg + 1
+    uint32_t get_column_orders_offsets_size() const { return 1 + columns + 1; }                // 1 + c + 1
+    uint32_t get_column_chunks_offsets_size() const { return row_groups * (1 + columns + 1); } // rg * (1 + c + 1)
+    uint32_t get_body_size() const
     {
         return get_num_rows_offsets_size() * sizeof(uint32_t) +
                get_row_numbers_size() * sizeof(uint32_t) +
@@ -368,29 +368,16 @@ void GenerateMetadataIndex(const char *parquet_path, const char *index_file_path
     }
 }
 
-std::shared_ptr<parquet::FileMetaData> ReadMetadata(const char *index_file_path,
+std::shared_ptr<parquet::FileMetaData> ReadMetadata(const DataHeader &dataHeader,
+                                                    const uint8_t* data_body,
+                                                    size_t body_size,
                                                     const std::vector<uint32_t> &row_groups,
                                                     const std::vector<uint32_t> &column_indices,
                                                     const std::vector<std::string> &column_names)
 {
-    auto f = std::unique_ptr<FILE, decltype(&fclose)>(fopen(index_file_path, "rb"), &fclose);
-    if (!f)
-    {
-        auto msg = std::string("I/O error when opening '") + index_file_path + "'";
-        throw std::logic_error(msg);
-    }
-
-    DataHeader dataHeader;
-    size_t read_bytes = fread(&dataHeader, 1, sizeof(dataHeader), f.get());
-    if (read_bytes != sizeof(dataHeader))
-    {
-        auto msg = std::string("I/O error when reading '") + index_file_path + "'";
-        throw std::logic_error(msg);
-    }
-
     if (memcmp(HEADER_V1, dataHeader.header, HEADER_V1_LENGTH) != 0)
     {
-        auto msg = std::string("File '") + index_file_path + "' has unexpected format!";
+        auto msg = std::string("Index file has unexpected format!");
         throw std::logic_error(msg);
     }
 
@@ -422,16 +409,6 @@ std::shared_ptr<parquet::FileMetaData> ReadMetadata(const char *index_file_path,
                 throw std::logic_error(msg);
             }
         }
-    }
-
-    auto body_size = dataHeader.get_body_size();
-    std::vector<uint8_t> data_body(body_size);
-
-    read_bytes = fread(&data_body[0], 1, data_body.size(), f.get());
-    if (read_bytes != data_body.size())
-    {
-        auto msg = std::string("I/O error when reading '") + index_file_path + "'";
-        throw std::logic_error(msg);
     }
 
     auto num_row_offsets = (uint32_t *)&data_body[0];
@@ -630,4 +607,67 @@ std::shared_ptr<parquet::FileMetaData> ReadMetadata(const char *index_file_path,
 
     uint32_t length = thriftCopier.GetDataSize();
     return parquet::FileMetaData::Make(thriftCopier.GetData(), &length);
+}
+
+std::shared_ptr<parquet::FileMetaData> ReadMetadata(const char *index_file_path,
+                                                    const std::vector<uint32_t> &row_groups,
+                                                    const std::vector<uint32_t> &column_indices,
+                                                    const std::vector<std::string> &column_names)
+{
+    auto f = std::unique_ptr<FILE, decltype(&fclose)>(fopen(index_file_path, "rb"), &fclose);
+    if (!f)
+    {
+        auto msg = std::string("I/O error when opening '") + index_file_path + "'";
+        throw std::logic_error(msg);
+    }
+
+    DataHeader dataHeader;
+    size_t read_bytes = fread(&dataHeader, 1, sizeof(dataHeader), f.get());
+    if (read_bytes != sizeof(dataHeader))
+    {
+        auto msg = std::string("I/O error when reading '") + index_file_path + "'";
+        throw std::logic_error(msg);
+    }
+
+    if (memcmp(HEADER_V1, dataHeader.header, HEADER_V1_LENGTH) != 0)
+    {
+        auto msg = std::string("File '") + index_file_path + "' has unexpected format!";
+        throw std::logic_error(msg);
+    }
+
+    auto body_size = dataHeader.get_body_size();
+    std::vector<uint8_t> data_body(body_size);
+
+    read_bytes = fread(&data_body[0], 1, data_body.size(), f.get());
+    if (read_bytes != data_body.size())
+    {
+        auto msg = std::string("I/O error when reading '") + index_file_path + "'";
+        throw std::logic_error(msg);
+    }
+
+    return ReadMetadata(dataHeader, &data_body[0], data_body.size(), row_groups, column_indices, column_names);
+}
+
+
+std::shared_ptr<parquet::FileMetaData> ReadMetadata(const unsigned char *index_data,
+                                                    size_t index_data_length,                                                    
+                                                    const std::vector<uint32_t> &row_groups,
+                                                    const std::vector<uint32_t> &column_indices,
+                                                    const std::vector<std::string> &column_names)
+{
+    if (index_data_length < sizeof(DataHeader))
+    {
+        auto msg = std::string("Index data is too small, length=") + std::to_string(index_data_length);
+        throw std::logic_error(msg);
+    }
+
+    const DataHeader* p_data_header = (const DataHeader*)index_data;
+    size_t expected_length = sizeof(DataHeader) + p_data_header->get_body_size();
+    if (index_data_length != expected_length)
+    {
+        auto msg = std::string("Index data has unexpected length, length=") + std::to_string(index_data_length) + ", expected=" + std::to_string(expected_length);
+        throw std::logic_error(msg);
+    }
+
+    return ReadMetadata(*p_data_header, &index_data[sizeof(DataHeader)], index_data_length - sizeof(DataHeader), row_groups, column_indices, column_names);
 }

--- a/python/palletjack/palletjack.h
+++ b/python/palletjack/palletjack.h
@@ -7,3 +7,9 @@ std::shared_ptr<parquet::FileMetaData> ReadMetadata(const char *index_file_path,
                                                     const std::vector<uint32_t> &row_groups,
                                                     const std::vector<uint32_t> &column_indices,
                                                     const std::vector<std::string> &column_names);
+
+std::shared_ptr<parquet::FileMetaData> ReadMetadata(const unsigned char *index_data,
+                                                    size_t index_data_length,
+                                                    const std::vector<uint32_t> &row_groups,
+                                                    const std::vector<uint32_t> &column_indices,
+                                                    const std::vector<std::string> &column_names);

--- a/python/palletjack/palletjack.h
+++ b/python/palletjack/palletjack.h
@@ -2,6 +2,7 @@
 #include "parquet/arrow/writer.h"
 #include "parquet/arrow/schema.h"
 
+std::vector<char> GenerateMetadataIndex(const char *parquet_path);
 void GenerateMetadataIndex(const char *parquet_path, const char *index_file_path);
 std::shared_ptr<parquet::FileMetaData> ReadMetadata(const char *index_file_path,
                                                     const std::vector<uint32_t> &row_groups,

--- a/python/palletjack/palletjack_cython.pyx
+++ b/python/palletjack/palletjack_cython.pyx
@@ -12,15 +12,21 @@ from pyarrow._parquet cimport *
 def generate_metadata_index(parquet_path, index_file_path):
     cpalletjack.GenerateMetadataIndex(parquet_path.encode('utf8'), index_file_path.encode('utf8'))
 
-cpdef read_metadata(index_file_path, row_groups = [], column_indices = [], column_names = []):
+cpdef read_metadata(index_file_path = None, index_data = None, row_groups = [], column_indices = [], column_names = []):
 
     cdef shared_ptr[CFileMetaData] c_metadata
-    cdef string encoded_path = index_file_path.encode('utf8')
+    cdef string encoded_path = index_file_path.encode('utf8') if index_file_path is not None else "".encode('utf8')
+    cdef const unsigned char[:] mv = index_data
     cdef vector[uint32_t] crow_groups = row_groups
     cdef vector[uint32_t] ccolumn_indices = column_indices
     cdef vector[string] ccolumn_names = [c.encode('utf8') for c in column_names]
-    with nogil:
-        c_metadata = cpalletjack.ReadMetadata(encoded_path.c_str(), crow_groups, ccolumn_indices, ccolumn_names)
+
+    if index_file_path is None:
+        with nogil:
+            c_metadata = cpalletjack.ReadMetadata(&mv[0], len(mv), crow_groups, ccolumn_indices, ccolumn_names)
+    else:
+        with nogil:
+            c_metadata = cpalletjack.ReadMetadata(encoded_path.c_str(), crow_groups, ccolumn_indices, ccolumn_names)
 
     cdef FileMetaData m = FileMetaData.__new__(FileMetaData)
     m.init(c_metadata)

--- a/python/palletjack/palletjack_cython.pyx
+++ b/python/palletjack/palletjack_cython.pyx
@@ -9,7 +9,7 @@ from libcpp.vector cimport vector
 from libc.stdint cimport uint32_t
 from pyarrow._parquet cimport *
 
-cpdef generate_metadata_index(parquet_path = None, index_file_path = None):
+cpdef generate_metadata_index(parquet_path, index_file_path = None):
     cdef string encoded_parquet_path = parquet_path.encode('utf8')
     cdef string encoded_index_file_path = index_file_path.encode('utf8') if index_file_path is not None else "".encode('utf8')
     cdef vector[char] c_index_data

--- a/python/palletjack/palletjack_cython.pyx
+++ b/python/palletjack/palletjack_cython.pyx
@@ -9,7 +9,7 @@ from libcpp.vector cimport vector
 from libc.stdint cimport uint32_t
 from pyarrow._parquet cimport *
 
-cpdef generate_metadata_index(parquet_path, index_file_path = None):
+cpdef generate_metadata_index(parquet_path = None, index_file_path = None):
     cdef string encoded_parquet_path = parquet_path.encode('utf8')
     cdef string encoded_index_file_path = index_file_path.encode('utf8') if index_file_path is not None else "".encode('utf8')
     cdef vector[char] c_index_data

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -10,7 +10,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "palletjack"
-version = "2.0.0"
+version = "2.1.0"
 authors = [
   { name="Marcin Krystianc", email="marcin.krystianc@gmail.com" },
 ]

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -10,7 +10,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "palletjack"
-version = "2.1.0"
+version = "2.0.0"
 authors = [
   { name="Marcin Krystianc", email="marcin.krystianc@gmail.com" },
 ]

--- a/python/test/test_palletjack.py
+++ b/python/test/test_palletjack.py
@@ -3,7 +3,6 @@ import tempfile
 
 import palletjack as pj
 import pyarrow.parquet as pq
-import numpy as np
 import pyarrow as pa
 import numpy as np
 import itertools as it

--- a/python/test/test_palletjack.py
+++ b/python/test/test_palletjack.py
@@ -5,8 +5,10 @@ import palletjack as pj
 import pyarrow.parquet as pq
 import numpy as np
 import pyarrow as pa
-import os
+import numpy as np
 import itertools as it
+import pyarrow.fs as fs
+import os
 
 n_row_groups = 5
 n_columns = 7
@@ -42,7 +44,15 @@ class TestPalletJack(unittest.TestCase):
             # Reading using the indexed metadata
             metadata = pj.read_metadata(index_path, row_groups=row_groups, column_indices=column_indices)
             metadata_names = pj.read_metadata(index_path, row_groups=row_groups, column_names=[f'column_{i}' for i in column_indices])
+            
+            filesystem= fs.LocalFileSystem()
+            input_stream = filesystem.open_input_stream(index_path)
+            input_data = input_stream.readall()
+            a= dir(filesystem)
+            metadata_names_data = pj.read_metadata(index_data = input_data, row_groups=row_groups, column_names=[f'column_{i}' for i in column_indices])
+            
             self.assertEqual(metadata, metadata_names, f"row_groups={row_groups}, column_indices={column_indices}")
+            self.assertEqual(metadata_names_data, metadata_names, f"row_groups={row_groups}, column_indices={column_indices}")
 
             pr = pq.ParquetReader()
             pr.open(parquet_path, metadata=metadata)

--- a/python/test/test_palletjack.py
+++ b/python/test/test_palletjack.py
@@ -44,12 +44,9 @@ class TestPalletJack(unittest.TestCase):
             # Reading using the indexed metadata
             metadata = pj.read_metadata(index_path, row_groups=row_groups, column_indices=column_indices)
             metadata_names = pj.read_metadata(index_path, row_groups=row_groups, column_names=[f'column_{i}' for i in column_indices])
-            
-            filesystem= fs.LocalFileSystem()
-            input_stream = filesystem.open_input_stream(index_path)
-            input_data = input_stream.readall()
-            a= dir(filesystem)
-            metadata_names_data = pj.read_metadata(index_data = input_data, row_groups=row_groups, column_names=[f'column_{i}' for i in column_indices])
+
+            metadata_names_data = pj.read_metadata(index_data = fs.LocalFileSystem().open_input_stream(index_path).readall()
+                                                   , row_groups=row_groups, column_names=[f'column_{i}' for i in column_indices])
             
             self.assertEqual(metadata, metadata_names, f"row_groups={row_groups}, column_indices={column_indices}")
             self.assertEqual(metadata_names_data, metadata_names, f"row_groups={row_groups}, column_indices={column_indices}")
@@ -169,6 +166,20 @@ class TestPalletJack(unittest.TestCase):
 
             res_data_index = pr.read_row_groups([0], use_threads=False)
             self.assertEqual(res_data_org, res_data_index, f"Row={r}")
+  
+    def test_inmemory_index_data(self):
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdirname:
+            path = os.path.join(tmpdirname, "my.parquet")
+            table = get_table()
+
+            pq.write_table(table, path, row_group_size=chunk_size, use_dictionary=False, write_statistics=False, store_schema=False)
+
+            index_path = path + '.index'
+            pj.generate_metadata_index(path, index_path)
+            index_data1 = pj.generate_metadata_index(path)
+            index_data2 = fs.LocalFileSystem().open_input_stream(index_path).readall()
+            # Compare the actual output to the expected output
+            self.assertEqual(index_data1, index_data2)
 
 if __name__ == '__main__':
     unittest.main()

--- a/python/test/test_readme.py
+++ b/python/test/test_readme.py
@@ -1,30 +1,5 @@
-# PalletJack
-PalletJack was created as a workaround for apache/arrow#38149. The standard parquet reader is not efficient for files with numerous columns and row groups, as it requires parsing the entire metadata section each time the file is opened. The size of this metadata section is proportional to the number of columns and row groups in the file.
-
-PalletJack reduces the amount of metadata bytes that need to be read and decoded by storing metadata in a different format. This approach enables reading only the essential subset of metadata as required.
-
-## Features
-
-- Storing parquet metadata in an indexed format
-- Reading parquet metadata for a subset of row groups and columns
-
-## Required:
-
-- pyarrow  ~= 15.0
- 
-PalletJack operates on top of pyarrow, making it an essential requirement for both building and using PalletJack. While our source package is compatible with recent versions of pyarrow, the binary distribution package specifically requires the latest major version of pyarrow.
-
-##  Installation
-
-```
-pip install palletjack
-```
-
-## How to use:
-
-
 ### Generating a sample parquet file:
-```
+# ```
 import palletjack as pj
 import pyarrow.parquet as pq
 import pyarrow.fs as fs
@@ -42,66 +17,66 @@ pa_arrays = [pa.array(data[:, i]) for i in range(columns)]
 column_names = [f'column_{i}' for i in range(columns)]
 table = pa.Table.from_arrays(pa_arrays, names=column_names)
 pq.write_table(table, path, row_group_size=chunk_size, use_dictionary=False, write_statistics=False, store_schema=False)
-```
+# ```
 
 ### Generating the metadata index file:
-```
+# ```
 index_path = path + '.index'
 pj.generate_metadata_index(path, index_path)
-```
+# ```
 
 ### Generating the in-memory metadata index:
-```
+# ```
 index_data = pj.generate_metadata_index(path)
-```
+# ```
 
 ### Writing the in-memory metadata index to a file using pyarrow's fs:
-```
+# ```
 fs.LocalFileSystem().open_output_stream(index_path).write(index_data)
-```
+# ```
 
 ### Reading the in-memory metadata index from a file using pyarrow's fs:
-```
+# ```
 index_data = fs.LocalFileSystem().open_input_stream(index_path).readall()
-```
+# ```
 
 ### Reading data with help of index file:
-```
+# ```
 metadata = pj.read_metadata(index_path, row_groups = [5, 7])
 pr = pq.ParquetReader()
 pr.open(path, metadata=metadata)
 data = pr.read_all()
-```
+# ```
 
 ### Reading data with help of in-memory index:
-```
+# ```
 metadata = pj.read_metadata(index_data = index_data, row_groups = [5, 7])
 pr = pq.ParquetReader()
 pr.open(path, metadata=metadata)
 data = pr.read_all()
-```
+# ```
 
 ### Reading subset of columns using column indices:
-```
+# ```
 metadata = pj.read_metadata(index_path, column_indices = [1, 3])
 pr = pq.ParquetReader()
 pr.open(path, metadata=metadata)
 data = pr.read_all()
-```
+# ```
 
 ### Reading subset of columns using column names:
-```
+# ```
 metadata = pj.read_metadata(index_path, column_names = ['column_1', 'column_3'])
 pr = pq.ParquetReader()
 pr.open(path, metadata=metadata)
 data = pr.read_all()
-```
+# ```
 
 ### Reading subset of row groups and columns:
-```
+# ```
 metadata = pj.read_metadata(index_path, row_groups = [5, 7], column_indices = [1, 3])
 pr = pq.ParquetReader()
 pr.open(path, metadata=metadata)
 
 data = pr.read_all()
-```
+# ```


### PR DESCRIPTION
In-memory index data has two benefits.
Firstly, it enables reading and writing index data using other file systems (e.g. `S3FileSystem`).
Secondly, index data needs much less RAM than `FileMetaData`. Therefore, even if there is not enough RAM to cache multiple `FileMetaData` objects, potentially it is possible to cache multiple in-memory index data objects.